### PR TITLE
Add ability to switch between whitelist/blacklist 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/hyperdefined/NoEndCrystals) [![Downloads](https://img.shields.io/github/downloads/hyperdefined/NoEndCrystals/total?logo=github)](https://github.com/hyperdefined/NoEndCrystals/releases) [![Donate with Bitcoin](https://en.cryptobadges.io/badge/micro/1F29aNKQzci3ga5LDcHHawYzFPXvELTFoL)](https://en.cryptobadges.io/donate/1F29aNKQzci3ga5LDcHHawYzFPXvELTFoL) [![Donate with Ethereum](https://en.cryptobadges.io/badge/micro/0x0f58B66993a315dbCc102b4276298B5Ff8895F41)](https://en.cryptobadges.io/donate/0x0f58B66993a315dbCc102b4276298B5Ff8895F41) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-NoEndCrystals allows you to disable placement of End Crystals in certain worlds.
+NoEndCrystals allows you to enable/disable placement of End Crystals in certain worlds.
 
 ## Features
-* Specify which worlds will disable placement.
+* Specify which worlds will enable/disable placement.
 * Set a custom message for when a player tries to place a crystal in a disabled world.
 
 ## Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>lol.hyper</groupId>
     <artifactId>noendcrystals</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/lol/hyper/noendcrystals/EndCrystalChecker.java
+++ b/src/main/java/lol/hyper/noendcrystals/EndCrystalChecker.java
@@ -19,6 +19,7 @@ package lol.hyper.noendcrystals;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -34,13 +35,20 @@ public class EndCrystalChecker implements Listener {
         this.noEndCrystals = noEndCrystals;
     }
 
+    private boolean allow(World world) {
+        boolean allow = noEndCrystals.config.getStringList("worlds").contains(world.getName());
+        return noEndCrystals.config.getBoolean("whitelist", true) == allow;
+    }
+
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(final PlayerInteractEvent event) {
         Player player = event.getPlayer();
         if (Action.RIGHT_CLICK_BLOCK == event.getAction()) {
+            if (event.getClickedBlock() == null)
+                return;
             if (event.getClickedBlock().getType().equals(Material.OBSIDIAN) || event.getClickedBlock().getType().equals(Material.BEDROCK)) {
                 if (Material.END_CRYSTAL == event.getMaterial()) {
-                    if (noEndCrystals.config.getStringList("disabled_worlds").contains(player.getWorld().getName())) {
+                    if (!allow(player.getWorld())) {
                         event.setCancelled(true);
                         player.sendMessage(ChatColor.translateAlternateColorCodes('&', noEndCrystals.config.get("message").toString()));
                     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
-disabled_worlds:
+whitelist: true
+worlds:
   - world1
   - world2
   - world3


### PR DESCRIPTION
When whitelist: true, only worlds defined in worlds will have endcrystals enabled. When whitelist: false (blacklist mode), only worlds defined in worlds will have endcrystals disabled.

Version bumped to 1.3